### PR TITLE
docs: Issue #1 メモ一覧画面の実装ドキュメントを追加

### DIFF
--- a/document/1_メモ一覧画面.md
+++ b/document/1_メモ一覧画面.md
@@ -1,0 +1,80 @@
+# Issue #1: メモ一覧画面（ListView）の基本実装
+
+## Issue概要
+
+ユーザーが保存したメモを時系列で確認できる一覧画面（HomeScreen）の実装。
+
+- **Issue**: [#1 [Feature] メモ一覧画面（ListView）の基本実装](https://github.com/nefuyu/chocotto_memo/issues/1)
+- **状態**: Closed（実装済み）
+- **実装日**: 2026-03-23
+
+---
+
+## 実装方針
+
+TDDに従い、テストを先に作成してから実装を行った。
+データ永続化（SQLite）は未実装のため、この時点では`List<Memo>`を外部から受け取るステートレスな設計とした。
+
+---
+
+## クラス / ファイル構成
+
+### `lib/models/memo.dart` — Memoモデル
+
+```dart
+class Memo {
+  final String title;
+  final String content;
+  final String emoji;
+  final DateTime createdAt;
+}
+```
+
+| フィールド  | 型         | 説明             |
+|------------|------------|-----------------|
+| `title`    | String     | メモのタイトル    |
+| `content`  | String     | メモの本文       |
+| `emoji`    | String     | 絵文字タグ       |
+| `createdAt`| DateTime   | 作成日時         |
+
+---
+
+### `lib/screens/home_screen.dart` — HomeScreen
+
+| 要素                      | 内容                                               |
+|--------------------------|----------------------------------------------------|
+| 種別                     | StatelessWidget                                    |
+| コンストラクタ引数         | `List<Memo> memos`                                 |
+| ヘルパーメソッド           | `_formatDate(DateTime)` → `yyyy/MM/dd` 形式に変換  |
+| 並び順                   | `createdAt` 降順（新しい順）                        |
+| 空の状態                  | 画面中央に「メモがありません。右下のボタンから作成しましょう」を表示 |
+| リストアイテム             | ListTile: leading=絵文字、title=タイトル、subtitle=本文1行省略、trailing=作成日時 |
+| FloatingActionButton     | `Icons.add`、タップ時は TODO コメントのみ（未実装）  |
+
+---
+
+### `lib/main.dart` — エントリポイント
+
+- `MaterialApp` を構成（テーマ: deepPurple seed、Material 3有効）
+- `HomeScreen` を空リスト `[]` で初期化（暫定）
+
+---
+
+## テスト方針
+
+**ファイル**: `test/home_screen_test.dart`
+
+| テストケース                           | 検証内容                                              |
+|--------------------------------------|------------------------------------------------------|
+| メモがある場合にリストが表示される       | `ListView` が描画され、タイトル文字列が存在する          |
+| メモがない場合に空メッセージが表示される | 空メッセージが表示され、`ListView` が存在しない          |
+| メモが降順（新しい順）で表示される      | より新しいメモのウィジェットが上部（y座標が小さい）に位置する |
+| FABが表示される                       | `FloatingActionButton` と `Icons.add` が存在する      |
+
+---
+
+## 既知の制約
+
+- **データ永続化なし**: この時点でSQLite未統合。`HomeScreen`はメモリ上の`List<Memo>`のみ扱う。
+- **FAB未実装**: メモ作成画面へのナビゲーションは未実装（TODOコメントのみ）。
+- **`widget_test.dart`**: プロジェクト生成時のボイラープレート（カウンターアプリ用）が残存しており、現在の実装とは無関係。


### PR DESCRIPTION
## Summary

- 解決済みIssue #1（メモ一覧画面・ListView基本実装）の後追いドキュメントを `document/1_メモ一覧画面.md` として作成
- ドキュメントにはIssue概要・実装方針・クラス/関数構成・テスト方針・既知の制約を記載

## 変更ファイル

- `document/1_メモ一覧画面.md` — 新規作成

## Test plan

- [ ] ドキュメントの内容が実装（`lib/models/memo.dart`, `lib/screens/home_screen.dart`）と一致していることを確認
- [ ] `test/home_screen_test.dart` の4テストケースがドキュメントに正しく記載されていることを確認

https://claude.ai/code/session_018dB7BWADxhU74zcpNw2dJZ