### PR TITLE
feat: Issue #4 メモの作成・編集画面を実装

### DIFF
--- a/document/4_メモの作成・編集画面.md
+++ b/document/4_メモの作成・編集画面.md
@@ -1,0 +1,97 @@
+# Issue #4: メモの作成・編集画面の実装
+
+## Issue概要
+
+ホーム画面のFloatingActionButton（FAB）を押しても何も起きない（TODO状態）。
+メモを作成・編集できる画面を実装する。
+
+## 実装方針
+
+- `HomeScreen` を `StatelessWidget` から `StatefulWidget` に変更し、`DatabaseService` を受け取る
+- `MemoEditScreen` を新規作成（新規作成・編集を同一画面で処理）
+- FABタップ → 新規作成画面遷移、メモタップ → 編集画面遷移
+- 保存後は `Navigator.pop()` でホーム画面に戻り、メモ一覧を再取得
+- `main.dart` でアプリ起動時に `DatabaseService` を初期化・open して `HomeScreen` に渡す
+
+## クラス/関数構成
+
+### `lib/screens/memo_edit_screen.dart`（新規）
+
+```
+MemoEditScreen (StatefulWidget)
+├── db: DatabaseService（必須）
+├── memo: Memo?（nullなら新規作成、非nullなら編集）
+└── _MemoEditScreenState
+    ├── _emojiController: TextEditingController（デフォルト: '📝'）
+    ├── _titleController: TextEditingController
+    ├── _contentController: TextEditingController
+    ├── _save() → Future<void>
+    │   ├── タイトルが空なら何もしない
+    │   ├── memo == null → db.insert() で新規保存
+    │   ├── memo != null → db.update() で更新
+    │   └── Navigator.pop() で戻る
+    └── build() → Scaffold
+        ├── AppBar: '新規作成' or '編集'
+        └── Column
+            ├── TextField（絵文字、maxLength: 2）
+            ├── TextField（タイトル）
+            ├── TextField（本文、maxLines: null）
+            └── ElevatedButton（保存）
+```
+
+### `lib/screens/home_screen.dart`（変更）
+
+```
+HomeScreen (StatefulWidget) ← StatelessWidget から変更
+├── db: DatabaseService（必須）← memos: List<Memo> から変更
+└── _HomeScreenState
+    ├── _memos: List<Memo>（状態）
+    ├── initState() → _loadMemos() を呼ぶ
+    ├── _loadMemos() → db.getAll() で取得・setState
+    └── _navigateToEdit({Memo? memo}) → MemoEditScreen へ遷移・戻り後 _loadMemos
+```
+
+### `lib/main.dart`（変更）
+
+- `main()` を `async` に変更
+- `WidgetsFlutterBinding.ensureInitialized()` を追加
+- `DatabaseService` を生成・`open()` してから `MyApp` に渡す
+
+## テスト方針
+
+### ウィジェットテストの工夫
+
+`sqflite_common_ffi` はバックグラウンドアイソレートを使うため、`testWidgets` の `FakeAsync` 環境内で動作しない（`await db.*` がハング）。
+
+対策として `test/fake_database_service.dart` に `FakeDatabaseService` を実装。List を使ってインメモリで動作させ、Future がマイクロタスクで即完了するため `pumpAndSettle()` が正常に動く。
+
+### `test/memo_edit_screen_test.dart`（新規、8テスト）
+
+| テスト名 | 検証内容 |
+|---------|---------|
+| 「新規作成」タイトルが表示される | AppBarにタイトルがある |
+| タイトル・本文・絵文字の入力フィールドが表示される | 3つのTextField+labelが存在 |
+| 保存ボタンが表示される | ElevatedButton('保存')が存在 |
+| 絵文字フィールドにデフォルト値が入っている | controller.text == '📝' |
+| タイトルを入力して保存するとDBに保存される | db.getAll()で1件取得できる |
+| 「編集」タイトルが表示される | 編集モードでAppBarタイトルが変わる |
+| 既存メモの値がフィールドに入っている | 各controllerに既存値がセットされている |
+| 編集して保存するとDBが更新される | db.getAll()で更新後の値が取得できる |
+
+### `test/home_screen_test.dart`（更新、6テスト）
+
+| テスト名 | 検証内容 |
+|---------|---------|
+| メモがある場合にリストが表示される | ListViewとタイトルが表示される |
+| メモがない場合に空メッセージが表示される | 空メッセージが表示される |
+| メモが降順（新しい順）で表示される | Y座標で新しいメモが上 |
+| FABが表示される | FloatingActionButton と Icons.add が存在 |
+| FABをタップするとMemoEditScreenへ遷移する | MemoEditScreen が表示される |
+| メモをタップするとMemoEditScreenへ遷移する | MemoEditScreen が表示される |
+
+## 既知の制約
+
+- 絵文字フィールドは `maxLength: 2` のテキスト入力のみ（絵文字ピッカーなし）
+- タイトルが空の場合は保存しない（バリデーションなし、サイレントスキップ）
+- `WidgetsFlutterBinding.ensureInitialized()` が必要なため、main() を async に変更した
+- ウィジェットテストでは `FakeDatabaseService` を使用し、実際のSQLite動作は `database_service_test.dart` で担保する

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:chocotto_memo/screens/home_screen.dart';
+import 'package:chocotto_memo/services/database_service.dart';
 
-void main() {
-  runApp(const MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final db = DatabaseService();
+  await db.open();
+  runApp(MyApp(db: db));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final DatabaseService db;
+
+  const MyApp({super.key, required this.db});
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +22,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const HomeScreen(memos: []),
+      home: HomeScreen(db: db),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,10 +1,42 @@
 import 'package:flutter/material.dart';
 import '../models/memo.dart';
+import '../services/database_service.dart';
+import 'memo_edit_screen.dart';
 
-class HomeScreen extends StatelessWidget {
-  final List<Memo> memos;
+class HomeScreen extends StatefulWidget {
+  final DatabaseService db;
 
-  const HomeScreen({super.key, required this.memos});
+  const HomeScreen({super.key, required this.db});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  List<Memo> _memos = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMemos();
+  }
+
+  Future<void> _loadMemos() async {
+    final memos = await widget.db.getAll();
+    setState(() {
+      _memos = memos;
+    });
+  }
+
+  Future<void> _navigateToEdit({Memo? memo}) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MemoEditScreen(db: widget.db, memo: memo),
+      ),
+    );
+    _loadMemos();
+  }
 
   String _formatDate(DateTime date) {
     final y = date.year.toString();
@@ -15,21 +47,18 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sorted = [...memos]
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('メモ一覧'),
       ),
-      body: sorted.isEmpty
+      body: _memos.isEmpty
           ? const Center(
               child: Text('メモがありません。右下のボタンから作成しましょう'),
             )
           : ListView.builder(
-              itemCount: sorted.length,
+              itemCount: _memos.length,
               itemBuilder: (context, index) {
-                final memo = sorted[index];
+                final memo = _memos[index];
                 return ListTile(
                   leading: Text(
                     memo.emoji,
@@ -42,13 +71,12 @@ class HomeScreen extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                   trailing: Text(_formatDate(memo.createdAt)),
+                  onTap: () => _navigateToEdit(memo: memo),
                 );
               },
             ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          // TODO: メモ作成画面への遷移
-        },
+        onPressed: () => _navigateToEdit(),
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/screens/memo_edit_screen.dart
+++ b/lib/screens/memo_edit_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import '../models/memo.dart';
+import '../services/database_service.dart';
+
+class MemoEditScreen extends StatefulWidget {
+  final DatabaseService db;
+  final Memo? memo;
+
+  const MemoEditScreen({super.key, required this.db, this.memo});
+
+  @override
+  State<MemoEditScreen> createState() => _MemoEditScreenState();
+}
+
+class _MemoEditScreenState extends State<MemoEditScreen> {
+  late final TextEditingController _emojiController;
+  late final TextEditingController _titleController;
+  late final TextEditingController _contentController;
+
+  @override
+  void initState() {
+    super.initState();
+    _emojiController = TextEditingController(text: widget.memo?.emoji ?? '📝');
+    _titleController = TextEditingController(text: widget.memo?.title ?? '');
+    _contentController = TextEditingController(text: widget.memo?.content ?? '');
+  }
+
+  @override
+  void dispose() {
+    _emojiController.dispose();
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final title = _titleController.text.trim();
+    final content = _contentController.text.trim();
+    final emoji = _emojiController.text.trim();
+
+    if (title.isEmpty) return;
+
+    if (widget.memo == null) {
+      await widget.db.insert(Memo(
+        title: title,
+        content: content,
+        emoji: emoji.isEmpty ? '📝' : emoji,
+        createdAt: DateTime.now(),
+      ));
+    } else {
+      await widget.db.update(Memo(
+        id: widget.memo!.id,
+        title: title,
+        content: content,
+        emoji: emoji.isEmpty ? '📝' : emoji,
+        createdAt: widget.memo!.createdAt,
+      ));
+    }
+
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isNew = widget.memo == null;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isNew ? '新規作成' : '編集'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _emojiController,
+              decoration: const InputDecoration(labelText: '絵文字'),
+              maxLength: 2,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'タイトル'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _contentController,
+              decoration: const InputDecoration(labelText: '本文'),
+              maxLines: null,
+              keyboardType: TextInputType.multiline,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -1,0 +1,46 @@
+import 'package:chocotto_memo/models/memo.dart';
+import 'package:chocotto_memo/services/database_service.dart';
+
+/// ウィジェットテスト用のFakeDatabaseService。
+/// sqflite_common_ffi はアイソレートを使うため testWidgets の FakeAsync 環境で動かない。
+/// このFakeはリストを使ってインメモリで動作し、Futureがマイクロタスクで即完了する。
+class FakeDatabaseService extends DatabaseService {
+  int _nextId = 1;
+  final List<Memo> _memos = [];
+
+  @override
+  Future<void> open() async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<int> insert(Memo memo) async {
+    final id = _nextId++;
+    _memos.add(Memo(
+      id: id,
+      title: memo.title,
+      content: memo.content,
+      emoji: memo.emoji,
+      createdAt: memo.createdAt,
+    ));
+    return id;
+  }
+
+  @override
+  Future<List<Memo>> getAll() async {
+    return [..._memos]
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  }
+
+  @override
+  Future<void> update(Memo memo) async {
+    final index = _memos.indexWhere((m) => m.id == memo.id);
+    if (index >= 0) _memos[index] = memo;
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    _memos.removeWhere((m) => m.id == id);
+  }
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -2,28 +2,37 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:chocotto_memo/models/memo.dart';
 import 'package:chocotto_memo/screens/home_screen.dart';
+import 'package:chocotto_memo/screens/memo_edit_screen.dart';
+import 'fake_database_service.dart';
 
 void main() {
+  late FakeDatabaseService db;
+
+  setUp(() {
+    db = FakeDatabaseService();
+  });
+
+  Future<void> pumpHomeScreen(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: HomeScreen(db: db)));
+    await tester.pumpAndSettle();
+  }
+
   group('HomeScreen', () {
     testWidgets('メモがある場合にリストが表示される', (WidgetTester tester) async {
-      final memos = [
-        Memo(
-          title: 'テストメモ1',
-          content: 'テスト内容1',
-          emoji: '📝',
-          createdAt: DateTime(2024, 1, 15),
-        ),
-        Memo(
-          title: 'テストメモ2',
-          content: 'テスト内容2',
-          emoji: '✅',
-          createdAt: DateTime(2024, 1, 10),
-        ),
-      ];
-
-      await tester.pumpWidget(MaterialApp(
-        home: HomeScreen(memos: memos),
+      await db.insert(Memo(
+        title: 'テストメモ1',
+        content: 'テスト内容1',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 15),
       ));
+      await db.insert(Memo(
+        title: 'テストメモ2',
+        content: 'テスト内容2',
+        emoji: '✅',
+        createdAt: DateTime(2024, 1, 10),
+      ));
+
+      await pumpHomeScreen(tester);
 
       expect(find.text('テストメモ1'), findsOneWidget);
       expect(find.text('テストメモ2'), findsOneWidget);
@@ -31,9 +40,7 @@ void main() {
     });
 
     testWidgets('メモがない場合に空メッセージが表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: HomeScreen(memos: []),
-      ));
+      await pumpHomeScreen(tester);
 
       expect(
         find.text('メモがありません。右下のボタンから作成しましょう'),
@@ -43,42 +50,57 @@ void main() {
     });
 
     testWidgets('メモが降順（新しい順）で表示される', (WidgetTester tester) async {
-      final memos = [
-        Memo(
-          title: '古いメモ',
-          content: '内容',
-          emoji: '📝',
-          createdAt: DateTime(2024, 1, 1),
-        ),
-        Memo(
-          title: '新しいメモ',
-          content: '内容',
-          emoji: '✅',
-          createdAt: DateTime(2024, 6, 1),
-        ),
-      ];
-
-      await tester.pumpWidget(MaterialApp(
-        home: HomeScreen(memos: memos),
+      await db.insert(Memo(
+        title: '古いメモ',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      await db.insert(Memo(
+        title: '新しいメモ',
+        content: '内容',
+        emoji: '✅',
+        createdAt: DateTime(2024, 6, 1),
       ));
 
-      final newMemoIndex = tester
-          .getTopLeft(find.text('新しいメモ'))
-          .dy;
-      final oldMemoIndex = tester
-          .getTopLeft(find.text('古いメモ'))
-          .dy;
+      await pumpHomeScreen(tester);
+
+      final newMemoIndex = tester.getTopLeft(find.text('新しいメモ')).dy;
+      final oldMemoIndex = tester.getTopLeft(find.text('古いメモ')).dy;
 
       expect(newMemoIndex, lessThan(oldMemoIndex));
     });
 
     testWidgets('FABが表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: HomeScreen(memos: []),
-      ));
+      await pumpHomeScreen(tester);
 
       expect(find.byType(FloatingActionButton), findsOneWidget);
       expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+
+    testWidgets('FABをタップするとMemoEditScreenへ遷移する', (WidgetTester tester) async {
+      await pumpHomeScreen(tester);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MemoEditScreen), findsOneWidget);
+    });
+
+    testWidgets('メモをタップするとMemoEditScreenへ遷移する', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: 'タップテスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      await tester.tap(find.text('タップテスト'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MemoEditScreen), findsOneWidget);
     });
   });
 }

--- a/test/memo_edit_screen_test.dart
+++ b/test/memo_edit_screen_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chocotto_memo/models/memo.dart';
+import 'package:chocotto_memo/screens/memo_edit_screen.dart';
+import 'fake_database_service.dart';
+
+void main() {
+  late FakeDatabaseService db;
+
+  setUp(() {
+    db = FakeDatabaseService();
+  });
+
+  Future<void> pumpEditScreen(WidgetTester tester, {Memo? memo}) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MemoEditScreen(db: db, memo: memo),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('MemoEditScreen - 新規作成', () {
+    testWidgets('「新規作成」タイトルが表示される', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+      expect(find.text('新規作成'), findsOneWidget);
+    });
+
+    testWidgets('タイトル・本文・絵文字の入力フィールドが表示される', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+      expect(find.text('タイトル'), findsOneWidget);
+      expect(find.text('本文'), findsOneWidget);
+      expect(find.text('絵文字'), findsOneWidget);
+    });
+
+    testWidgets('保存ボタンが表示される', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+      expect(find.text('保存'), findsOneWidget);
+    });
+
+    testWidgets('絵文字フィールドにデフォルト値が入っている', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+      // フィールド順: 0=絵文字, 1=タイトル, 2=本文
+      final emojiField = tester.widget<TextField>(find.byType(TextField).at(0));
+      expect(emojiField.controller?.text, '📝');
+    });
+
+    testWidgets('タイトルを入力して保存するとDBに保存される', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+
+      await tester.enterText(find.byType(TextField).at(1), 'テストタイトル');
+      await tester.enterText(find.byType(TextField).at(2), 'テスト本文');
+
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+
+      final memos = await db.getAll();
+      expect(memos.length, 1);
+      expect(memos.first.title, 'テストタイトル');
+      expect(memos.first.content, 'テスト本文');
+    });
+  });
+
+  group('MemoEditScreen - 編集', () {
+    testWidgets('「編集」タイトルが表示される', (WidgetTester tester) async {
+      final id = await db.insert(Memo(
+        title: '既存タイトル',
+        content: '既存本文',
+        emoji: '🔥',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      final memo = (await db.getAll()).first;
+      await pumpEditScreen(tester, memo: memo);
+
+      expect(find.text('編集'), findsOneWidget);
+    });
+
+    testWidgets('既存メモの値がフィールドに入っている', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '既存タイトル',
+        content: '既存本文',
+        emoji: '🔥',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      final memo = (await db.getAll()).first;
+      await pumpEditScreen(tester, memo: memo);
+
+      final emojiField = tester.widget<TextField>(find.byType(TextField).at(0));
+      final titleField = tester.widget<TextField>(find.byType(TextField).at(1));
+      final contentField = tester.widget<TextField>(find.byType(TextField).at(2));
+
+      expect(emojiField.controller?.text, '🔥');
+      expect(titleField.controller?.text, '既存タイトル');
+      expect(contentField.controller?.text, '既存本文');
+    });
+
+    testWidgets('編集して保存するとDBが更新される', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '旧タイトル',
+        content: '旧本文',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      final memo = (await db.getAll()).first;
+      await pumpEditScreen(tester, memo: memo);
+
+      await tester.enterText(find.byType(TextField).at(1), '新タイトル');
+
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+
+      final memos = await db.getAll();
+      expect(memos.length, 1);
+      expect(memos.first.title, '新タイトル');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `lib/screens/memo_edit_screen.dart` を新規作成（絵文字・タイトル・本文のフォーム、新規作成/編集を同一画面で処理）
- `lib/screens/home_screen.dart` を `StatefulWidget` に変更し、DB から一覧を読み込むよう更新
- FAB タップ → 新規作成画面、メモタップ → 編集画面へ遷移し、戻り後に一覧を再取得
- `lib/main.dart` でアプリ起動時に `DatabaseService` を open して `HomeScreen` に渡すよう変更

## テスト

- `test/memo_edit_screen_test.dart` を新規追加（8テスト）
- `test/home_screen_test.dart` を更新（6テスト、画面遷移テスト含む）
- `test/fake_database_service.dart` を追加（sqflite_common_ffi が testWidgets の FakeAsync 内で動かないため List ベース Fake を実装）
- 全21テスト（widget 14 + DB 7）PASS

## Closes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)