### PR TITLE
fix: widget_test.dartのコンパイルエラーを修正

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:chocotto_memo/main.dart';
+import 'fake_database_service.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('アプリが起動してホーム画面が表示される', (WidgetTester tester) async {
+    final db = FakeDatabaseService();
+    await tester.pumpWidget(MyApp(db: db));
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('メモ一覧'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- `MyApp` に `required this.db` パラメータが追加されたが、`test/widget_test.dart` が未更新のままでコンパイルエラーが発生していた
- `FakeDatabaseService` を注入して `MyApp(db: db)` で起動するよう修正
- テスト内容をFlutterデフォルトのカウンター確認から、現アプリのホーム画面表示確認（`'メモ一覧'` テキストが存在する）に変更

## Test plan

- [ ] `flutter test` を実行して全22テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)