### PR TITLE
fix: SettingsService.save()でsetIntの書き込み失敗を検知して例外を投げる

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -22,7 +22,10 @@ class SettingsService {
 
   Future<void> save(AppSettings settings) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_keyTheme, settings.theme.index);
-    await prefs.setInt(_keyFontSize, settings.fontSize.index);
+    final themeOk = await prefs.setInt(_keyTheme, settings.theme.index);
+    final fontSizeOk = await prefs.setInt(_keyFontSize, settings.fontSize.index);
+    if (!themeOk || !fontSizeOk) {
+      throw Exception('設定の書き込みに失敗しました');
+    }
   }
 }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -65,5 +65,17 @@ void main() {
       expect(settings.theme, AppTheme.system);
       expect(settings.fontSize, AppFontSize.medium);
     });
+
+    test('save()はテーマとフォントサイズを両方正しく書き込む', () async {
+      final service = SettingsService();
+      // 例外が投げられなければ書き込み成功（setIntがfalseを返した場合は例外になる）
+      await expectLater(
+        service.save(const AppSettings(theme: AppTheme.dark, fontSize: AppFontSize.large)),
+        completes,
+      );
+      final settings = await service.load();
+      expect(settings.theme, AppTheme.dark);
+      expect(settings.fontSize, AppFontSize.large);
+    });
   });
 }


### PR DESCRIPTION
## Summary

codex PR #12 レビュー指摘（P2）への対応。

- `SharedPreferences.setInt()` は `Future<bool>` を返すが、従来の実装では戻り値を無視していた
- `false` が返った場合（例外なしの書き込み失敗）でも `SettingsNotifier.save()` が成功扱いになり、`savedSettings` が更新される
- 次回アプリ起動時に設定が元に戻るという不整合が発生しうる
- `setInt` の結果を確認し、`false` の場合は `Exception` を throw するよう修正
- これにより `SettingsNotifier.save()` の `catch` 節が動作してプレビューの巻き戻しと `saveError` セットが正しく機能する

## Test plan

- [ ] `settings_service_test.dart` に `save()` が正常完了することを確認するテストを追加済み
- [ ] 既存の保存・復元テストがすべて引き続き通ること