### PR TITLE
fix: テーマとフォントサイズをJSONで1キーにアトミック保存する

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,18 +1,23 @@
+import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/app_settings.dart';
 
 class SettingsService {
-  static const _keyTheme = 'theme';
-  static const _keyFontSize = 'fontSize';
+  static const _keySettings = 'settings';
 
   Future<AppSettings> load() async {
     final prefs = await SharedPreferences.getInstance();
-    final themeIndex = prefs.getInt(_keyTheme);
-    final fontSizeIndex = prefs.getInt(_keyFontSize);
-    return AppSettings(
-      theme: _parseEnum(AppTheme.values, themeIndex, AppTheme.system),
-      fontSize: _parseEnum(AppFontSize.values, fontSizeIndex, AppFontSize.medium),
-    );
+    final raw = prefs.getString(_keySettings);
+    if (raw != null) {
+      try {
+        final map = jsonDecode(raw) as Map<String, dynamic>;
+        return AppSettings(
+          theme: _parseEnum(AppTheme.values, map['theme'] as int?, AppTheme.system),
+          fontSize: _parseEnum(AppFontSize.values, map['fontSize'] as int?, AppFontSize.medium),
+        );
+      } catch (_) {}
+    }
+    return const AppSettings(theme: AppTheme.system, fontSize: AppFontSize.medium);
   }
 
   T _parseEnum<T>(List<T> values, int? index, T fallback) {
@@ -22,9 +27,9 @@ class SettingsService {
 
   Future<void> save(AppSettings settings) async {
     final prefs = await SharedPreferences.getInstance();
-    final themeOk = await prefs.setInt(_keyTheme, settings.theme.index);
-    final fontSizeOk = await prefs.setInt(_keyFontSize, settings.fontSize.index);
-    if (!themeOk || !fontSizeOk) {
+    final json = jsonEncode({'theme': settings.theme.index, 'fontSize': settings.fontSize.index});
+    final ok = await prefs.setString(_keySettings, json);
+    if (!ok) {
       throw Exception('設定の書き込みに失敗しました');
     }
   }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -45,30 +45,37 @@ void main() {
     });
 
     test('テーマに範囲外のインデックスが保存されていてもデフォルト(system)にフォールバックする', () async {
-      SharedPreferences.setMockInitialValues({'theme': 999});
+      SharedPreferences.setMockInitialValues({'settings': '{"theme":999,"fontSize":1}'});
       final service = SettingsService();
       final settings = await service.load();
       expect(settings.theme, AppTheme.system);
     });
 
     test('フォントサイズに範囲外のインデックスが保存されていてもデフォルト(medium)にフォールバックする', () async {
-      SharedPreferences.setMockInitialValues({'fontSize': 999});
+      SharedPreferences.setMockInitialValues({'settings': '{"theme":0,"fontSize":999}'});
       final service = SettingsService();
       final settings = await service.load();
       expect(settings.fontSize, AppFontSize.medium);
     });
 
     test('負のインデックスが保存されていてもデフォルトにフォールバックする', () async {
-      SharedPreferences.setMockInitialValues({'theme': -1, 'fontSize': -1});
+      SharedPreferences.setMockInitialValues({'settings': '{"theme":-1,"fontSize":-1}'});
       final service = SettingsService();
       final settings = await service.load();
       expect(settings.theme, AppTheme.system);
       expect(settings.fontSize, AppFontSize.medium);
     });
 
-    test('save()はテーマとフォントサイズを両方正しく書き込む', () async {
+    test('不正なJSONが保存されていてもデフォルト設定にフォールバックする', () async {
+      SharedPreferences.setMockInitialValues({'settings': 'invalid_json'});
       final service = SettingsService();
-      // 例外が投げられなければ書き込み成功（setIntがfalseを返した場合は例外になる）
+      final settings = await service.load();
+      expect(settings.theme, AppTheme.system);
+      expect(settings.fontSize, AppFontSize.medium);
+    });
+
+    test('save()はテーマとフォントサイズを1つのキーにアトミックに書き込む', () async {
+      final service = SettingsService();
       await expectLater(
         service.save(const AppSettings(theme: AppTheme.dark, fontSize: AppFontSize.large)),
         completes,


### PR DESCRIPTION
## Summary

codex PR #12 レビュー指摘（P2）への対応。

- `theme` と `fontSize` を独立した2つの `setInt` 呼び出しで保存していたため、片方が成功・片方が失敗した場合に SharedPreferences に設定が混在した状態が残る問題があった
- `jsonEncode` で両値を1つのJSON文字列にまとめ `setString` で1回だけ書き込むことでアトミック性を保証
- 1回の書き込みなので `false` が返った場合も設定が混在することなく失敗扱いになる
- 不正なJSONや欠損キーの場合もデフォルト設定にフォールバックするよう `try-catch` で保護

## Test plan

- [ ] テーマ・フォントサイズの保存・復元テストが引き続き通ること
- [ ] 範囲外インデックス・負値インデックスのフォールバックテスト（JSON形式に更新済み）
- [ ] 不正なJSONが保存されていてもクラッシュせずデフォルトにフォールバックするテストを追加