### PR TITLE
feat(#18): バリデーション失敗とDB例外をSnackBarで通知する

### DIFF
--- a/document/18_エラーハンドリングとバリデーション通知.md
+++ b/document/18_エラーハンドリングとバリデーション通知.md
@@ -1,0 +1,49 @@
+# Issue #18: アプリ基盤 — エラーハンドリングとバリデーション通知の統一
+
+## Issue 概要
+
+アプリ全体のエラー表示方法とバリデーション失敗時の通知方法が未定義だった。
+根幹部分として方針を決定し、実装する。
+
+## 実装方針
+
+### バリデーション失敗時
+- タイトルが空のまま保存ボタンを押した場合、`SnackBar` で「タイトルを入力してください」と表示する
+- 従来は `if (title.isEmpty) return;` で黙って何もしていなかった（UX上の問題）
+
+### DB操作の例外ハンドリング
+- `insert` / `update` を `try/catch` で囲み、例外発生時は `SnackBar` で「保存に失敗しました」と通知する
+- 正常時は従来どおり `Navigator.pop` で画面を閉じる
+
+## クラス / 関数構成
+
+### `lib/screens/memo_edit_screen.dart`
+
+- `_save()` メソッドを変更
+  - タイトル空チェック → `ScaffoldMessenger.of(context).showSnackBar(...)` でバリデーションエラーを表示
+  - DB操作を `try/catch` で囲み、`catch` ブロックで `SnackBar` によるエラー通知
+
+### `test/fake_database_service.dart`
+
+- `shouldThrow` フィールド（`bool`, デフォルト `false`）を追加
+- `shouldThrow == true` のとき `insert` / `update` / `delete` が `Exception('DB error')` を投げる
+
+### `test/memo_edit_screen_test.dart`
+
+- グループ「バリデーション」を追加
+  - タイトルが空で保存するとSnackBarが表示されること
+  - タイトルが空のときDBには保存されないこと
+- グループ「DB例外ハンドリング」を追加
+  - 新規作成でDB例外が発生するとSnackBarが表示されること
+  - 編集でDB例外が発生するとSnackBarが表示されること
+
+## テスト方針
+
+- ウィジェットテストで `FakeDatabaseService` を使用
+- `shouldThrow = true` にセットしてDB例外パスをテスト
+- `find.text(...)` でSnackBarのメッセージが画面に表示されることを確認
+
+## 既知の制約
+
+- `main.dart` の `db.open()` 失敗時（起動時のDB障害）は本Issueのスコープ外
+- SnackBarは後から表示されたものが上書きするため、連打時に最初のメッセージが消える場合がある

--- a/lib/screens/memo_edit_screen.dart
+++ b/lib/screens/memo_edit_screen.dart
@@ -38,26 +38,38 @@ class _MemoEditScreenState extends State<MemoEditScreen> {
     final content = _contentController.text.trim();
     final emoji = _emojiController.text.trim();
 
-    if (title.isEmpty) return;
-
-    if (widget.memo == null) {
-      await widget.db.insert(Memo(
-        title: title,
-        content: content,
-        emoji: emoji.isEmpty ? '📝' : emoji,
-        createdAt: DateTime.now(),
-      ));
-    } else {
-      await widget.db.update(Memo(
-        id: widget.memo!.id,
-        title: title,
-        content: content,
-        emoji: emoji.isEmpty ? '📝' : emoji,
-        createdAt: widget.memo!.createdAt,
-      ));
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('タイトルを入力してください')),
+      );
+      return;
     }
 
-    if (mounted) Navigator.pop(context);
+    try {
+      if (widget.memo == null) {
+        await widget.db.insert(Memo(
+          title: title,
+          content: content,
+          emoji: emoji.isEmpty ? '📝' : emoji,
+          createdAt: DateTime.now(),
+        ));
+      } else {
+        await widget.db.update(Memo(
+          id: widget.memo!.id,
+          title: title,
+          content: content,
+          emoji: emoji.isEmpty ? '📝' : emoji,
+          createdAt: widget.memo!.createdAt,
+        ));
+      }
+      if (mounted) Navigator.pop(context);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('保存に失敗しました')),
+        );
+      }
+    }
   }
 
   @override

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -8,6 +8,9 @@ class FakeDatabaseService extends DatabaseService {
   int _nextId = 1;
   final List<Memo> _memos = [];
 
+  /// trueにするとinsert/update/deleteが例外を投げる
+  bool shouldThrow = false;
+
   @override
   Future<void> open() async {}
 
@@ -16,6 +19,7 @@ class FakeDatabaseService extends DatabaseService {
 
   @override
   Future<int> insert(Memo memo) async {
+    if (shouldThrow) throw Exception('DB error');
     final id = _nextId++;
     _memos.add(Memo(
       id: id,
@@ -35,12 +39,14 @@ class FakeDatabaseService extends DatabaseService {
 
   @override
   Future<void> update(Memo memo) async {
+    if (shouldThrow) throw Exception('DB error');
     final index = _memos.indexWhere((m) => m.id == memo.id);
     if (index >= 0) _memos[index] = memo;
   }
 
   @override
   Future<void> delete(int id) async {
+    if (shouldThrow) throw Exception('DB error');
     _memos.removeWhere((m) => m.id == id);
   }
 }

--- a/test/memo_edit_screen_test.dart
+++ b/test/memo_edit_screen_test.dart
@@ -114,4 +114,56 @@ void main() {
       expect(memos.first.title, '新タイトル');
     });
   });
+
+  group('MemoEditScreen - バリデーション', () {
+    testWidgets('タイトルが空のまま保存するとSnackBarが表示される', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+
+      await tester.tap(find.text('保存'));
+      await tester.pump();
+
+      expect(find.text('タイトルを入力してください'), findsOneWidget);
+    });
+
+    testWidgets('タイトルが空のときDBには保存されない', (WidgetTester tester) async {
+      await pumpEditScreen(tester);
+
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+
+      expect(await db.getAll(), isEmpty);
+    });
+  });
+
+  group('MemoEditScreen - DB例外ハンドリング', () {
+    testWidgets('新規作成でDB例外が発生するとSnackBarが表示される', (WidgetTester tester) async {
+      db.shouldThrow = true;
+      await pumpEditScreen(tester);
+
+      await tester.enterText(find.byType(TextField).at(1), 'タイトル');
+      await tester.tap(find.text('保存'));
+      await tester.pump();
+
+      expect(find.text('保存に失敗しました'), findsOneWidget);
+    });
+
+    testWidgets('編集でDB例外が発生するとSnackBarが表示される', (WidgetTester tester) async {
+      db.shouldThrow = false;
+      await db.insert(Memo(
+        title: '既存',
+        content: '',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      final memo = (await db.getAll()).first;
+      db.shouldThrow = true;
+      await pumpEditScreen(tester, memo: memo);
+
+      await tester.enterText(find.byType(TextField).at(1), '更新後');
+      await tester.tap(find.text('保存'));
+      await tester.pump();
+
+      expect(find.text('保存に失敗しました'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
- タイトル空のまま保存するとSnackBar「タイトルを入力してください」を表示
- insert/update を try/catch で囲みDB例外時にSnackBar「保存に失敗しました」を表示
- FakeDatabaseService に shouldThrow フラグを追加してDB例外テストを可能に
- MemoEditScreen の対応テスト4件を追加

https://claude.ai/code/session_014BL3kFHv55yNdfP8gx7u2V