### PR TITLE
feat(#24): memos テーブルに updated_at カラムを追加し、ソート順を updated_at DESC に変更

### DIFF
--- a/document/24_updated_atカラム追加.md
+++ b/document/24_updated_atカラム追加.md
@@ -1,0 +1,61 @@
+# Issue #24: memos テーブルに updated_at カラムを追加
+
+## Issue 概要
+
+`memos` テーブルに `updated_at` カラムを追加し、ソート順を `created_at DESC` から `updated_at DESC` へ変更する。
+
+## 実装方針
+
+- TDD: テスト先行で実装
+- DBバージョンを 1 → 2 に上げ、`onUpgrade` で既存レコードに `updated_at = created_at` を設定するマイグレーションを実装
+- `DatabaseService.update()` が呼ばれた際、サービス層で `updated_at` を `DateTime.now()` に上書きする
+
+## クラス / 関数構成
+
+### `lib/models/memo.dart`
+
+| 変更点 | 内容 |
+|---|---|
+| フィールド追加 | `final DateTime updatedAt` |
+| コンストラクタ | `required this.updatedAt` を追加 |
+| `toMap()` | `'updated_at': updatedAt.toIso8601String()` を追加 |
+| `fromMap()` | `updatedAt: DateTime.parse(map['updated_at'])` を追加 |
+
+### `lib/services/database_service.dart`
+
+| 変更点 | 内容 |
+|---|---|
+| `_dbVersion` | `1` → `2` |
+| `onCreate` | `updated_at TEXT NOT NULL` カラムを追加 |
+| `onUpgrade` | `ALTER TABLE memos ADD COLUMN updated_at ...` + `UPDATE SET updated_at = created_at` |
+| `getAll()` | `orderBy: 'updated_at DESC'` |
+| `update()` | `map['updated_at'] = DateTime.now().toIso8601String()` で上書き |
+
+### `lib/screens/memo_edit_screen.dart`
+
+- 新規作成時: `updatedAt: now`（`createdAt` と同じ値）
+- 編集時: `updatedAt: widget.memo!.updatedAt`（サービス側で上書きされる）
+
+### `test/fake_database_service.dart`
+
+- `insert()`: `updatedAt` を保存
+- `getAll()`: `updatedAt DESC` でソート
+- `update()`: `updatedAt = DateTime.now()` で上書き
+
+## テスト方針
+
+### `test/database_service_test.dart`
+
+| テスト | 内容 |
+|---|---|
+| `toMap includes all fields` | `updated_at` が含まれることを確認 |
+| `fromMap restores Memo correctly` | `updatedAt` が正しく復元されることを確認 |
+| `update changes memo fields and sets updatedAt to now` | 更新後に `updatedAt` が現在時刻に更新されることを確認 |
+| `getAll returns memos sorted by updatedAt descending` | ソート順が `updated_at DESC` であることを確認 |
+
+既存テストも `Memo` コンストラクタの `updatedAt` 引数追加に合わせて更新。
+
+## 既知の制約
+
+- インメモリDBを使ったテストのため、`onUpgrade` マイグレーションのテストは省略（新規スキーマで動作確認）
+- `home_screen.dart` の表示日付は引き続き `createdAt` を表示（表示変更は別Issue対応）

--- a/lib/models/memo.dart
+++ b/lib/models/memo.dart
@@ -4,6 +4,7 @@ class Memo {
   final String content;
   final String emoji;
   final DateTime createdAt;
+  final DateTime updatedAt;
 
   Memo({
     this.id,
@@ -11,6 +12,7 @@ class Memo {
     required this.content,
     required this.emoji,
     required this.createdAt,
+    required this.updatedAt,
   });
 
   Map<String, dynamic> toMap() {
@@ -20,6 +22,7 @@ class Memo {
       'content': content,
       'emoji': emoji,
       'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
     };
   }
 
@@ -30,6 +33,7 @@ class Memo {
       content: map['content'] as String,
       emoji: map['emoji'] as String,
       createdAt: DateTime.parse(map['created_at'] as String),
+      updatedAt: DateTime.parse(map['updated_at'] as String),
     );
   }
 }

--- a/lib/screens/memo_edit_screen.dart
+++ b/lib/screens/memo_edit_screen.dart
@@ -47,11 +47,13 @@ class _MemoEditScreenState extends State<MemoEditScreen> {
 
     try {
       if (widget.memo == null) {
+        final now = DateTime.now();
         await widget.db.insert(Memo(
           title: title,
           content: content,
           emoji: emoji.isEmpty ? '📝' : emoji,
-          createdAt: DateTime.now(),
+          createdAt: now,
+          updatedAt: now,
         ));
       } else {
         await widget.db.update(Memo(
@@ -60,6 +62,7 @@ class _MemoEditScreenState extends State<MemoEditScreen> {
           content: content,
           emoji: emoji.isEmpty ? '📝' : emoji,
           createdAt: widget.memo!.createdAt,
+          updatedAt: widget.memo!.updatedAt,
         ));
       }
       if (mounted) Navigator.pop(context);

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -4,7 +4,7 @@ import '../models/memo.dart';
 
 class DatabaseService {
   static const _tableName = 'memos';
-  static const _dbVersion = 1;
+  static const _dbVersion = 2;
 
   final String? path;
   Database? _db;
@@ -23,9 +23,20 @@ class DatabaseService {
             title TEXT NOT NULL,
             content TEXT NOT NULL,
             emoji TEXT NOT NULL,
-            created_at TEXT NOT NULL
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
           )
         ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute(
+            'ALTER TABLE $_tableName ADD COLUMN updated_at TEXT NOT NULL DEFAULT ""',
+          );
+          await db.execute(
+            'UPDATE $_tableName SET updated_at = created_at',
+          );
+        }
       },
     );
   }
@@ -42,15 +53,17 @@ class DatabaseService {
   Future<List<Memo>> getAll() async {
     final rows = await _db!.query(
       _tableName,
-      orderBy: 'created_at DESC',
+      orderBy: 'updated_at DESC',
     );
     return rows.map(Memo.fromMap).toList();
   }
 
   Future<void> update(Memo memo) async {
+    final map = memo.toMap();
+    map['updated_at'] = DateTime.now().toIso8601String();
     await _db!.update(
       _tableName,
-      memo.toMap(),
+      map,
       where: 'id = ?',
       whereArgs: [memo.id],
     );

--- a/test/database_service_test.dart
+++ b/test/database_service_test.dart
@@ -28,6 +28,7 @@ void main() {
         content: '本文',
         emoji: '📝',
         createdAt: DateTime(2026, 3, 24),
+        updatedAt: DateTime(2026, 3, 25),
       );
       final map = memo.toMap();
       expect(map['id'], 1);
@@ -35,6 +36,7 @@ void main() {
       expect(map['content'], '本文');
       expect(map['emoji'], '📝');
       expect(map['created_at'], '2026-03-24T00:00:00.000');
+      expect(map['updated_at'], '2026-03-25T00:00:00.000');
     });
 
     test('fromMap restores Memo correctly', () {
@@ -44,6 +46,7 @@ void main() {
         'content': '内容',
         'emoji': '🔥',
         'created_at': '2026-01-01T00:00:00.000',
+        'updated_at': '2026-01-02T00:00:00.000',
       };
       final memo = Memo.fromMap(map);
       expect(memo.id, 2);
@@ -51,16 +54,19 @@ void main() {
       expect(memo.content, '内容');
       expect(memo.emoji, '🔥');
       expect(memo.createdAt, DateTime(2026, 1, 1));
+      expect(memo.updatedAt, DateTime(2026, 1, 2));
     });
   });
 
   group('DatabaseService CRUD', () {
     test('insert and getAll returns the memo', () async {
+      final now = DateTime(2026, 3, 24);
       final memo = Memo(
         title: 'Hello',
         content: 'World',
         emoji: '👋',
-        createdAt: DateTime(2026, 3, 24),
+        createdAt: now,
+        updatedAt: now,
       );
       await db.insert(memo);
       final all = await db.getAll();
@@ -69,52 +75,72 @@ void main() {
       expect(all.first.id, isNotNull);
     });
 
-    test('update changes memo fields', () async {
+    test('update changes memo fields and sets updatedAt to now', () async {
+      final createdAt = DateTime(2026, 3, 24);
       final memo = Memo(
         title: '旧タイトル',
         content: '旧内容',
         emoji: '😴',
-        createdAt: DateTime(2026, 3, 24),
+        createdAt: createdAt,
+        updatedAt: createdAt,
       );
       final id = await db.insert(memo);
+      final beforeUpdate = DateTime.now();
       final updated = Memo(
         id: id,
         title: '新タイトル',
         content: '新内容',
         emoji: '🎉',
-        createdAt: memo.createdAt,
+        createdAt: createdAt,
+        updatedAt: createdAt, // サービス側で上書きされる
       );
       await db.update(updated);
+      final afterUpdate = DateTime.now();
       final all = await db.getAll();
       expect(all.length, 1);
       expect(all.first.title, '新タイトル');
       expect(all.first.emoji, '🎉');
+      // updatedAt がupdate呼び出し時刻付近に更新されていること
+      expect(
+        all.first.updatedAt.isAfter(beforeUpdate.subtract(const Duration(seconds: 1))),
+        isTrue,
+      );
+      expect(
+        all.first.updatedAt.isBefore(afterUpdate.add(const Duration(seconds: 1))),
+        isTrue,
+      );
     });
 
     test('delete removes the memo', () async {
+      final now = DateTime(2026, 3, 24);
       final id = await db.insert(Memo(
         title: '削除対象',
         content: '',
         emoji: '🗑️',
-        createdAt: DateTime(2026, 3, 24),
+        createdAt: now,
+        updatedAt: now,
       ));
       await db.delete(id);
       final all = await db.getAll();
       expect(all, isEmpty);
     });
 
-    test('getAll returns memos sorted by createdAt descending', () async {
+    test('getAll returns memos sorted by updatedAt descending', () async {
+      final old = DateTime(2026, 1, 1);
+      final recent = DateTime(2026, 3, 24);
       await db.insert(Memo(
         title: '古い',
         content: '',
         emoji: '📅',
-        createdAt: DateTime(2026, 1, 1),
+        createdAt: old,
+        updatedAt: old,
       ));
       await db.insert(Memo(
         title: '新しい',
         content: '',
         emoji: '🆕',
-        createdAt: DateTime(2026, 3, 24),
+        createdAt: recent,
+        updatedAt: recent,
       ));
       final all = await db.getAll();
       expect(all.first.title, '新しい');
@@ -122,12 +148,14 @@ void main() {
     });
 
     test('multiple inserts accumulate', () async {
+      final now = DateTime(2026, 3, 24);
       for (var i = 0; i < 3; i++) {
         await db.insert(Memo(
           title: 'メモ$i',
           content: '',
           emoji: '📌',
-          createdAt: DateTime(2026, 3, 24),
+          createdAt: now,
+          updatedAt: now,
         ));
       }
       final all = await db.getAll();

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -27,6 +27,7 @@ class FakeDatabaseService extends DatabaseService {
       content: memo.content,
       emoji: memo.emoji,
       createdAt: memo.createdAt,
+      updatedAt: memo.updatedAt,
     ));
     return id;
   }
@@ -34,14 +35,23 @@ class FakeDatabaseService extends DatabaseService {
   @override
   Future<List<Memo>> getAll() async {
     return [..._memos]
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
   }
 
   @override
   Future<void> update(Memo memo) async {
     if (shouldThrow) throw Exception('DB error');
     final index = _memos.indexWhere((m) => m.id == memo.id);
-    if (index >= 0) _memos[index] = memo;
+    if (index >= 0) {
+      _memos[index] = Memo(
+        id: memo.id,
+        title: memo.title,
+        content: memo.content,
+        emoji: memo.emoji,
+        createdAt: memo.createdAt,
+        updatedAt: DateTime.now(),
+      );
+    }
   }
 
   @override

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -34,12 +34,14 @@ void main() {
         content: 'テスト内容1',
         emoji: '📝',
         createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
       ));
       await db.insert(Memo(
         title: 'テストメモ2',
         content: 'テスト内容2',
         emoji: '✅',
         createdAt: DateTime(2024, 1, 10),
+        updatedAt: DateTime(2024, 1, 10),
       ));
 
       await pumpHomeScreen(tester);
@@ -65,12 +67,14 @@ void main() {
         content: '内容',
         emoji: '📝',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
       await db.insert(Memo(
         title: '新しいメモ',
         content: '内容',
         emoji: '✅',
         createdAt: DateTime(2024, 6, 1),
+        updatedAt: DateTime(2024, 6, 1),
       ));
 
       await pumpHomeScreen(tester);
@@ -103,6 +107,7 @@ void main() {
         content: '内容',
         emoji: '📝',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
 
       await pumpHomeScreen(tester);

--- a/test/memo_edit_screen_test.dart
+++ b/test/memo_edit_screen_test.dart
@@ -63,11 +63,12 @@ void main() {
 
   group('MemoEditScreen - 編集', () {
     testWidgets('「編集」タイトルが表示される', (WidgetTester tester) async {
-      final id = await db.insert(Memo(
+      await db.insert(Memo(
         title: '既存タイトル',
         content: '既存本文',
         emoji: '🔥',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
       final memo = (await db.getAll()).first;
       await pumpEditScreen(tester, memo: memo);
@@ -81,6 +82,7 @@ void main() {
         content: '既存本文',
         emoji: '🔥',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
       final memo = (await db.getAll()).first;
       await pumpEditScreen(tester, memo: memo);
@@ -100,6 +102,7 @@ void main() {
         content: '旧本文',
         emoji: '📝',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
       final memo = (await db.getAll()).first;
       await pumpEditScreen(tester, memo: memo);
@@ -154,6 +157,7 @@ void main() {
         content: '',
         emoji: '📝',
         createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
       ));
       final memo = (await db.getAll()).first;
       db.shouldThrow = true;


### PR DESCRIPTION
- Memo モデルに updatedAt フィールドを追加（toMap/fromMap 更新）
- DatabaseService の DB バージョンを 2 に上げ、onUpgrade マイグレーションを実装
- getAll() のソートを updated_at DESC に変更
- update() でサービス側が updated_at を DateTime.now() で上書き
- FakeDatabaseService・各テストファイルを updatedAt 対応に更新
- SDD ドキュメントを document/24_updated_atカラム追加.md に追加

https://claude.ai/code/session_01Uq7Azq8yqhzcZNNKDtFckn