### PR TITLE
feat(#33): 長押しコンテキストメニューとAlertDialogによるメモ削除機能を実装

### DIFF
--- a/document/20260401045510_削除機能.md
+++ b/document/20260401045510_削除機能.md
@@ -1,0 +1,40 @@
+# 削除機能（長押しコンテキストメニュー＋確認ダイアログ）
+
+## Issue概要
+
+Issue #33：メモ一覧画面に長押しコンテキストメニューを追加し、確認ダイアログを経てメモを削除する機能を実装する。
+
+## 実装方針
+
+- `ListTile` を `GestureDetector` でラップし、`onLongPressStart` でタップ位置（`details.globalPosition`）を取得する。
+- `showMenu()` を使って長押し位置近くにコンテキストメニューを表示する。現時点のメニュー項目は「削除」のみ。
+- 「削除」選択後は `AlertDialog` で確認ダイアログを表示し、誤操作を防ぐ。
+- 削除確定時は `DatabaseService.delete()` を呼び出し、`_loadMemos()` でリストを再取得する。
+- DB操作失敗時は `try/catch` で捕捉し、SnackBar でエラーを通知する。
+- Undo なし（確認ダイアログが誤操作防止の役割を担う）。
+
+## クラス/関数構成
+
+### `lib/screens/home_screen.dart`
+
+| 関数 | 説明 |
+|------|------|
+| `_onLongPress(context, memo, tapPosition)` | `showMenu()` を呼び出しメニュー表示。「削除」選択時に `_confirmDelete` へ委譲。|
+| `_confirmDelete(context, memo)` | `AlertDialog` で確認後、`db.delete()` を実行。失敗時は SnackBar 通知。|
+
+`ListView.builder` 内の各アイテムを `GestureDetector` でラップし、`onLongPressStart` で `_onLongPress` を呼び出す。
+
+## テスト方針
+
+`test/home_screen_test.dart` に以下のテストを追加（TDD）：
+
+1. メモを長押しするとコンテキストメニューが表示される
+2. メニューから「削除」を選ぶと確認ダイアログが表示される
+3. 確認ダイアログで「削除」をタップするとメモが削除される
+4. 確認ダイアログで「キャンセル」をタップするとメモが残る
+5. DB削除失敗時に SnackBar が表示される
+
+## 既知の制約
+
+- `showMenu()` の表示位置は `details.globalPosition` を使用するため、長押し開始座標に追従する。
+- 将来的なメニュー項目追加（共有、複製など）は `PopupMenuItem` を追加するだけで対応可能な構造になっている。

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -49,13 +49,15 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _onLongPress(BuildContext context, Memo memo, Offset tapPosition) async {
+    final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final overlaySize = overlay.size;
     final selected = await showMenu<String>(
       context: context,
       position: RelativeRect.fromLTRB(
         tapPosition.dx,
         tapPosition.dy,
-        tapPosition.dx,
-        tapPosition.dy,
+        overlaySize.width - tapPosition.dx,
+        overlaySize.height - tapPosition.dy,
       ),
       items: const [
         PopupMenuItem(value: 'delete', child: Text('削除')),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -48,6 +48,58 @@ class _HomeScreenState extends State<HomeScreen> {
     return '$y/$m/$d';
   }
 
+  Future<void> _onLongPress(BuildContext context, Memo memo, Offset tapPosition) async {
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        tapPosition.dx,
+        tapPosition.dy,
+        tapPosition.dx,
+        tapPosition.dy,
+      ),
+      items: const [
+        PopupMenuItem(value: 'delete', child: Text('削除')),
+      ],
+    );
+
+    if (selected == 'delete' && context.mounted) {
+      await _confirmDelete(context, memo);
+    }
+  }
+
+  Future<void> _confirmDelete(BuildContext context, Memo memo) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await widget.db.delete(memo.id!);
+      await _loadMemos();
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('削除に失敗しました')),
+        );
+        await _loadMemos();
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -75,19 +127,23 @@ class _HomeScreenState extends State<HomeScreen> {
               itemCount: _memos.length,
               itemBuilder: (context, index) {
                 final memo = _memos[index];
-                return ListTile(
-                  leading: Text(
-                    memo.emoji,
-                    style: const TextStyle(fontSize: 24),
+                return GestureDetector(
+                  onLongPressStart: (details) =>
+                      _onLongPress(context, memo, details.globalPosition),
+                  child: ListTile(
+                    leading: Text(
+                      memo.emoji,
+                      style: const TextStyle(fontSize: 24),
+                    ),
+                    title: Text(memo.title),
+                    subtitle: Text(
+                      memo.content,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    trailing: Text(_formatDate(memo.createdAt)),
+                    onTap: () => _navigateToEdit(memo: memo),
                   ),
-                  title: Text(memo.title),
-                  subtitle: Text(
-                    memo.content,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  trailing: Text(_formatDate(memo.createdAt)),
-                  onTap: () => _navigateToEdit(memo: memo),
                 );
               },
             ),

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -133,4 +133,111 @@ void main() {
       expect(find.byType(SettingsScreen), findsOneWidget);
     });
   });
+
+  group('HomeScreen - 削除機能', () {
+    testWidgets('メモを長押しするとコンテキストメニューが表示される', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '削除テスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      await tester.longPress(find.text('削除テスト'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('削除'), findsOneWidget);
+    });
+
+    testWidgets('コンテキストメニューの「削除」を選ぶと確認ダイアログが表示される', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '削除テスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      await tester.longPress(find.text('削除テスト'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('削除'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('削除しますか？'), findsOneWidget);
+    });
+
+    testWidgets('確認ダイアログで「削除」をタップするとメモが削除される', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '削除テスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      await tester.longPress(find.text('削除テスト'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('削除'));
+      await tester.pumpAndSettle();
+      // AlertDialog内の「削除」ボタン
+      await tester.tap(find.widgetWithText(TextButton, '削除'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('削除テスト'), findsNothing);
+      expect(
+        find.text('メモがありません。右下のボタンから作成しましょう'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('確認ダイアログで「キャンセル」をタップするとメモが残る', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '削除テスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      await tester.longPress(find.text('削除テスト'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('削除'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('キャンセル'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('削除テスト'), findsOneWidget);
+    });
+
+    testWidgets('DB削除失敗時にSnackBarが表示される', (WidgetTester tester) async {
+      await db.insert(Memo(
+        title: '削除テスト',
+        content: '内容',
+        emoji: '📝',
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ));
+
+      await pumpHomeScreen(tester);
+
+      db.shouldThrow = true;
+      await tester.longPress(find.text('削除テスト'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('削除'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, '削除'));
+      await tester.pump();
+
+      expect(find.text('削除に失敗しました'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
- ListTileをGestureDetectorでラップしonLongPressStartでタップ位置を取得
- showMenu()で「削除」コンテキストメニューを表示
- AlertDialogで削除確認後db.delete()を実行
- DB失敗時はSnackBarで通知
- home_screen_test.dartに削除フローのテスト5件を追加（TDD）