### PR TITLE
feat(#26): 全メモ一覧の無限スクロール実装（100件ずつ分割読み込み）

### DIFF
--- a/document/20260401052829_無限スクロール.md
+++ b/document/20260401052829_無限スクロール.md
@@ -1,0 +1,62 @@
+# 無限スクロール実装（100件ずつ分割読み込み）
+
+## Issue 概要
+
+Issue #26: 全メモ一覧の無限スクロール実装（100件ずつ分割読み込み）
+
+メモ件数が増えた際のパフォーマンス向上のため、全メモ一覧画面に無限スクロール（ページネーション）を実装する。
+
+## 実装方針
+
+- `DatabaseService.getAll()` に `limit` / `offset` の任意パラメータを追加（後方互換性を維持）
+- `HomeScreen` に `ScrollController` を導入し、スクロール位置が末尾 200px 以内に達したら次ページをロードする
+- ローディング中は ListView の末尾に `CircularProgressIndicator` を表示
+- テスト用に `perPage` をコンストラクタ引数として公開（デフォルト 100）
+
+## クラス / 関数構成
+
+### `lib/services/database_service.dart`
+
+| メソッド | 変更内容 |
+|---------|---------|
+| `getAll({int? limit, int? offset})` | `limit` / `offset` の省略可能パラメータを追加。sqflite の query に渡す |
+
+### `test/fake_database_service.dart`
+
+| メソッド | 変更内容 |
+|---------|---------|
+| `getAll({int? limit, int? offset})` | インメモリリストに対して skip/take で limit/offset を模倣 |
+
+### `lib/screens/home_screen.dart`
+
+| 追加要素 | 説明 |
+|---------|-----|
+| `perPage` コンストラクタ引数 | 1ページあたりの取得件数（デフォルト 100） |
+| `_isLoading` 状態 | 追加読み込み中フラグ |
+| `_hasMore` 状態 | まだ未読み込みのデータが存在するかどうか |
+| `ScrollController _scrollController` | スクロール位置監視用 |
+| `_onScroll()` | 末尾 200px 以内に到達したら `_loadMore()` を呼び出す |
+| `_loadMore()` | 次ページを取得して `_memos` に追記する |
+| `_loadMemos()` | 変更: `getAll(limit: perPage, offset: 0)` で1ページ目のみ取得 |
+| `itemCount` | `_memos.length + (_isLoading ? 1 : 0)` でローディング行を追加 |
+
+## テスト方針
+
+### `test/database_service_test.dart`（DatabaseService pagination グループ）
+
+- `getAll(limit: 3)` が最大 3 件を返すこと
+- `getAll(limit: 2, offset: 3)` が 4〜5 番目のメモを返すこと
+- `offset` が総件数を超えたとき空リストを返すこと
+- `getAll()` を引数なしで呼ぶと全件返すこと
+
+### `test/home_screen_test.dart`（HomeScreen - 無限スクロール グループ）
+
+- 件数が `perPage` 以下のとき全件表示されること
+- 件数が `perPage` を超えるとき最初のページのみ読み込まれること（2ページ目のメモはツリーにない）
+- スクロールで追加ページが読み込まれること（`fling` → `pumpAndSettle` → `scrollUntilVisible`）
+- 全件ロード済みのときはローディングインジケータが表示されないこと
+
+## 既知の制約
+
+- `_loadMemos()`（編集・削除後のリロード）は常に1ページ目から再取得する。ユーザーが2ページ目以降を閲覧中に編集・削除した場合、リストが先頭に戻る。
+- スクロール位置が末尾から 200px 以内という閾値は固定値。リスト高さが閾値より小さい（全件が 1 スクロール未満に収まる）場合でも初期表示時にトリガーされないよう `_isLoading && !_hasMore` チェックで制御している。

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -25,6 +25,7 @@ class _HomeScreenState extends State<HomeScreen> {
   List<Memo> _memos = [];
   bool _isLoading = false;
   bool _hasMore = true;
+  int _loadGeneration = 0;
   final ScrollController _scrollController = ScrollController();
 
   @override
@@ -50,22 +51,29 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _loadMemos() async {
+    _loadGeneration++;
     final memos = await widget.db.getAll(limit: widget.perPage, offset: 0);
     if (!mounted) return;
     setState(() {
       _memos = memos;
       _hasMore = memos.length == widget.perPage;
+      _isLoading = false;
     });
   }
 
   Future<void> _loadMore() async {
     if (_isLoading || !_hasMore) return;
     setState(() => _isLoading = true);
+    final generation = _loadGeneration;
     final memos = await widget.db.getAll(
       limit: widget.perPage,
       offset: _memos.length,
     );
     if (!mounted) return;
+    if (generation != _loadGeneration) {
+      setState(() => _isLoading = false);
+      return;
+    }
     setState(() {
       _memos.addAll(memos);
       _hasMore = memos.length == widget.perPage;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -52,6 +52,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _loadMemos() async {
     _loadGeneration++;
+    setState(() => _isLoading = true);
     final memos = await widget.db.getAll(limit: widget.perPage, offset: 0);
     if (!mounted) return;
     setState(() {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,8 +8,14 @@ import 'settings_screen.dart';
 class HomeScreen extends StatefulWidget {
   final DatabaseService db;
   final SettingsNotifier settingsNotifier;
+  final int perPage;
 
-  const HomeScreen({super.key, required this.db, required this.settingsNotifier});
+  const HomeScreen({
+    super.key,
+    required this.db,
+    required this.settingsNotifier,
+    this.perPage = 100,
+  });
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -17,17 +23,51 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   List<Memo> _memos = [];
+  bool _isLoading = false;
+  bool _hasMore = true;
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
+    _scrollController.addListener(_onScroll);
     _loadMemos();
   }
 
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+            _scrollController.position.maxScrollExtent - 200 &&
+        !_isLoading &&
+        _hasMore) {
+      _loadMore();
+    }
+  }
+
   Future<void> _loadMemos() async {
-    final memos = await widget.db.getAll();
+    final memos = await widget.db.getAll(limit: widget.perPage, offset: 0);
     setState(() {
       _memos = memos;
+      _hasMore = memos.length == widget.perPage;
+    });
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || !_hasMore) return;
+    setState(() => _isLoading = true);
+    final memos = await widget.db.getAll(
+      limit: widget.perPage,
+      offset: _memos.length,
+    );
+    setState(() {
+      _memos.addAll(memos);
+      _hasMore = memos.length == widget.perPage;
+      _isLoading = false;
     });
   }
 
@@ -126,8 +166,17 @@ class _HomeScreenState extends State<HomeScreen> {
               child: Text('メモがありません。右下のボタンから作成しましょう'),
             )
           : ListView.builder(
-              itemCount: _memos.length,
+              controller: _scrollController,
+              itemCount: _memos.length + (_isLoading ? 1 : 0),
               itemBuilder: (context, index) {
+                if (index == _memos.length) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(16),
+                      child: CircularProgressIndicator(),
+                    ),
+                  );
+                }
                 final memo = _memos[index];
                 return GestureDetector(
                   onLongPressStart: (details) =>

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -51,6 +51,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _loadMemos() async {
     final memos = await widget.db.getAll(limit: widget.perPage, offset: 0);
+    if (!mounted) return;
     setState(() {
       _memos = memos;
       _hasMore = memos.length == widget.perPage;
@@ -64,6 +65,7 @@ class _HomeScreenState extends State<HomeScreen> {
       limit: widget.perPage,
       offset: _memos.length,
     );
+    if (!mounted) return;
     setState(() {
       _memos.addAll(memos);
       _hasMore = memos.length == widget.perPage;

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -50,10 +50,12 @@ class DatabaseService {
     return await _db!.insert(_tableName, memo.toMap());
   }
 
-  Future<List<Memo>> getAll() async {
+  Future<List<Memo>> getAll({int? limit, int? offset}) async {
     final rows = await _db!.query(
       _tableName,
       orderBy: 'updated_at DESC',
+      limit: limit,
+      offset: offset,
     );
     return rows.map(Memo.fromMap).toList();
   }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -53,7 +53,7 @@ class DatabaseService {
   Future<List<Memo>> getAll({int? limit, int? offset}) async {
     final rows = await _db!.query(
       _tableName,
-      orderBy: 'updated_at DESC',
+      orderBy: 'updated_at DESC, id DESC',
       limit: limit,
       offset: offset,
     );

--- a/test/database_service_test.dart
+++ b/test/database_service_test.dart
@@ -162,4 +162,46 @@ void main() {
       expect(all.length, 3);
     });
   });
+
+  group('DatabaseService pagination', () {
+    Future<void> insertN(int count) async {
+      for (var i = 0; i < count; i++) {
+        final dt = DateTime(2026, 1, i + 1);
+        await db.insert(Memo(
+          title: 'メモ$i',
+          content: '',
+          emoji: '📌',
+          createdAt: dt,
+          updatedAt: dt,
+        ));
+      }
+    }
+
+    test('getAll with limit returns at most limit memos', () async {
+      await insertN(5);
+      final result = await db.getAll(limit: 3);
+      expect(result.length, 3);
+    });
+
+    test('getAll with offset skips first N memos (sorted DESC)', () async {
+      await insertN(5);
+      // updatedAt DESC: メモ4, メモ3, メモ2, メモ1, メモ0
+      final result = await db.getAll(limit: 2, offset: 3);
+      expect(result.length, 2);
+      expect(result[0].title, 'メモ1');
+      expect(result[1].title, 'メモ0');
+    });
+
+    test('getAll returns empty list when offset exceeds total', () async {
+      await insertN(3);
+      final result = await db.getAll(limit: 10, offset: 10);
+      expect(result, isEmpty);
+    });
+
+    test('getAll without limit/offset returns all memos', () async {
+      await insertN(5);
+      final result = await db.getAll();
+      expect(result.length, 5);
+    });
+  });
 }

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -33,9 +33,12 @@ class FakeDatabaseService extends DatabaseService {
   }
 
   @override
-  Future<List<Memo>> getAll() async {
-    return [..._memos]
+  Future<List<Memo>> getAll({int? limit, int? offset}) async {
+    final sorted = [..._memos]
       ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    final start = offset ?? 0;
+    final sliced = sorted.skip(start);
+    return (limit == null ? sliced : sliced.take(limit)).toList();
   }
 
   @override

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -35,7 +35,11 @@ class FakeDatabaseService extends DatabaseService {
   @override
   Future<List<Memo>> getAll({int? limit, int? offset}) async {
     final sorted = [..._memos]
-      ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      ..sort((a, b) {
+        final cmp = b.updatedAt.compareTo(a.updatedAt);
+        if (cmp != 0) return cmp;
+        return (b.id ?? 0).compareTo(a.id ?? 0);
+      });
     final start = offset ?? 0;
     final sliced = sorted.skip(start);
     return (limit == null ? sliced : sliced.take(limit)).toList();

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -27,6 +27,9 @@ class FakeDatabaseService extends DatabaseService {
     _getAllHold[callIndex]?.complete();
   }
 
+  /// これまでに呼ばれた getAll の回数（テスト用）
+  int get getAllCallCount => _getAllCallIndex;
+
   @override
   Future<void> open() async {}
 

--- a/test/fake_database_service.dart
+++ b/test/fake_database_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:chocotto_memo/models/memo.dart';
 import 'package:chocotto_memo/services/database_service.dart';
 
@@ -10,6 +12,20 @@ class FakeDatabaseService extends DatabaseService {
 
   /// trueにするとinsert/update/deleteが例外を投げる
   bool shouldThrow = false;
+
+  // --- getAll の呼び出し番号別一時停止機構 (Completerベース) ---
+  int _getAllCallIndex = 0;
+  final Map<int, Completer<void>> _getAllHold = {};
+
+  /// [callIndex] 番目（1始まり）の getAll 呼び出しを一時停止させる
+  void holdGetAllCallAt(int callIndex) {
+    _getAllHold[callIndex] = Completer<void>();
+  }
+
+  /// [callIndex] 番目の停止中 getAll を解放する
+  void releaseGetAllCallAt(int callIndex) {
+    _getAllHold[callIndex]?.complete();
+  }
 
   @override
   Future<void> open() async {}
@@ -34,6 +50,10 @@ class FakeDatabaseService extends DatabaseService {
 
   @override
   Future<List<Memo>> getAll({int? limit, int? offset}) async {
+    final callIdx = ++_getAllCallIndex;
+    if (_getAllHold.containsKey(callIdx)) {
+      await _getAllHold[callIdx]!.future;
+    }
     final sorted = [..._memos]
       ..sort((a, b) {
         final cmp = b.updatedAt.compareTo(a.updatedAt);

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -239,6 +239,43 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.text('ページメモ01'), findsNothing);
     });
+
+    testWidgets('_loadMemos実行中は_isLoadingがtrueになり_loadMoreが抑制される',
+        (WidgetTester tester) async {
+      // 5件、perPage=3 → 初期ロード3件(_hasMore=true)
+      // 3件×72px=216px < viewport600px なので CPI がviewport内に収まる
+      await insertMemos(5);
+
+      // Call 2（navigation後の_loadMemos）を一時停止
+      db.holdGetAllCallAt(2);
+
+      await pumpHomeScreen(tester, perPage: 3);
+      expect(db.getAllCallCount, 1);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      // FAB → MemoEditScreen 遷移
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400)); // push アニメーション完了
+
+      // 戻る → _loadMemos (Call 2: 保留) 開始 → _isLoading=true
+      await tester.tap(find.byType(BackButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400)); // pop アニメーション + _loadMemos 開始
+      await tester.pump(); // setState(_isLoading=true) の rebuild 処理
+
+      // _loadMemos が getAll を await 中: _isLoading=true → CPI が表示される
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(db.getAllCallCount, 2); // _loadMore は呼ばれていない
+
+      // Call 2 を解放 → _loadMemos 完了 → _isLoading=false
+      db.releaseGetAllCallAt(2);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(db.getAllCallCount, 2); // _loadMore は最後まで呼ばれていない
+    });
   });
 
   group('HomeScreen - 削除機能', () {

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -20,9 +20,11 @@ void main() {
     await settingsNotifier.load();
   });
 
-  Future<void> pumpHomeScreen(WidgetTester tester) async {
+  Future<void> pumpHomeScreen(WidgetTester tester, {int perPage = 100}) async {
     await tester.pumpWidget(
-      MaterialApp(home: HomeScreen(db: db, settingsNotifier: settingsNotifier)),
+      MaterialApp(
+        home: HomeScreen(db: db, settingsNotifier: settingsNotifier, perPage: perPage),
+      ),
     );
     await tester.pumpAndSettle();
   }
@@ -131,6 +133,70 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(SettingsScreen), findsOneWidget);
+    });
+  });
+
+  group('HomeScreen - 無限スクロール', () {
+    Future<void> insertMemos(int count) async {
+      for (int i = 0; i < count; i++) {
+        await db.insert(Memo(
+          title: 'ページメモ${i.toString().padLeft(2, '0')}',
+          content: '内容',
+          emoji: '📝',
+          createdAt: DateTime(2024, 1, i + 1),
+          updatedAt: DateTime(2024, 1, i + 1),
+        ));
+      }
+    }
+
+    testWidgets('件数がperPage以下のとき全件表示される', (WidgetTester tester) async {
+      await insertMemos(5);
+      await pumpHomeScreen(tester, perPage: 10);
+
+      // 最新 = ページメモ04, 最古 = ページメモ00
+      expect(find.text('ページメモ04'), findsOneWidget);
+      expect(find.text('ページメモ00'), findsOneWidget);
+    });
+
+    testWidgets('件数がperPageを超えるとき最初のページのみ読み込まれる', (WidgetTester tester) async {
+      await insertMemos(12);
+      await pumpHomeScreen(tester, perPage: 10);
+
+      // 最新10件（ページメモ11〜ページメモ02）がロード済み
+      expect(find.text('ページメモ11'), findsOneWidget);
+      // 2ページ目のメモはまだウィジェットツリーに存在しない
+      expect(find.text('ページメモ01'), findsNothing);
+      expect(find.text('ページメモ00'), findsNothing);
+    });
+
+    testWidgets('スクロールで追加ページが読み込まれる', (WidgetTester tester) async {
+      await insertMemos(12);
+      await pumpHomeScreen(tester, perPage: 10);
+
+      // 初期状態: 2ページ目は未ロード
+      expect(find.text('ページメモ01'), findsNothing);
+
+      // リスト末尾へスクロール（10件×72px=720px > viewport600px なので可能）
+      await tester.fling(find.byType(ListView), const Offset(0, -600), 2000);
+      await tester.pumpAndSettle();
+
+      // 追加ロード後、2ページ目のアイテムを探してスクロール
+      await tester.scrollUntilVisible(
+        find.text('ページメモ01'),
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(find.text('ページメモ01'), findsOneWidget);
+    });
+
+    testWidgets('全件ロード済みのときはそれ以上ロードしない', (WidgetTester tester) async {
+      await insertMemos(5);
+      await pumpHomeScreen(tester, perPage: 10);
+
+      // 5件全件表示（hasMore=false のはず）
+      expect(find.text('ページメモ04'), findsOneWidget);
+      expect(find.text('ページメモ00'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
     });
   });
 

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -198,6 +198,47 @@ void main() {
       expect(find.text('ページメモ00'), findsOneWidget);
       expect(find.byType(CircularProgressIndicator), findsNothing);
     });
+
+    testWidgets('_loadMore実行中に_loadMemosが呼ばれると_loadMoreの結果は破棄される',
+        (WidgetTester tester) async {
+      await insertMemos(12);
+
+      // 2回目の getAll（_loadMore）を一時停止
+      // Call 1 = initState の _loadMemos、Call 2 = スクロール後の _loadMore
+      db.holdGetAllCallAt(2);
+
+      await pumpHomeScreen(tester, perPage: 10);
+      // Call 1 完了: 10件ロード済み
+      expect(find.text('ページメモ11'), findsOneWidget);
+      expect(find.text('ページメモ01'), findsNothing);
+
+      // ドラッグでスクロール → _onScroll → _loadMore (Call 2: 保留) 開始
+      // CPI アニメーションが無限に frame をスケジュールするため pumpAndSettle は
+      // タイムアウトする。固定 pump で代替する。
+      await tester.drag(find.byType(Scrollable).first, const Offset(0, -50));
+      await tester.pump(); // drag処理 → _loadMore 開始
+      await tester.pump(); // _isLoading = true の setState 処理
+
+      // FAB → MemoEditScreen 遷移（push animation 300ms を超えた時間を pump）
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump(); // タップ処理
+      await tester.pump(const Duration(milliseconds: 400)); // 遷移アニメーション完了
+
+      // 戻る → pop animation + _loadMemos (Call 3: 即完了) + _loadGeneration 更新
+      await tester.tap(find.byType(BackButton));
+      await tester.pump(); // タップ処理
+      await tester.pump(const Duration(milliseconds: 400)); // 戻り遷移 + _loadMemos 実行
+      await tester.pump(); // _loadMemos の setState 処理 (_isLoading = false)
+
+      // Call 2 を解放 → generation 不一致 (旧 < 新) で結果を破棄
+      db.releaseGetAllCallAt(2);
+      await tester.pump(); // _loadMore 再開 → generation チェック → 破棄
+      await tester.pump(); // setState(_isLoading = false) 処理
+
+      // stale な追記はされず、_isLoading もリセットされる
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('ページメモ01'), findsNothing);
+    });
   });
 
   group('HomeScreen - 削除機能', () {


### PR DESCRIPTION
- DatabaseService.getAll() に limit/offset パラメータを追加（後方互換）
- FakeDatabaseService.getAll() にも同パラメータを対応
- HomeScreen に ScrollController を導入し末尾付近で自動追加ロード
- perPage コンストラクタ引数（デフォルト100）でページサイズを制御
- ローディング中は ListView 末尾に CircularProgressIndicator を表示
- TDD: database_service_test / home_screen_test に pagination テスト追加
- SDD: document/20260401052829_無限スクロール.md を作成

https://claude.ai/code/session_01Y4RsDJw7Dz52Py2q5h4fLY