### PR TITLE
refactor: RadioListTile.onChangedのdeprecation対応

### DIFF
--- a/document/20260401215210_RadioListTile_onChanged_deprecation対応.md
+++ b/document/20260401215210_RadioListTile_onChanged_deprecation対応.md
@@ -1,0 +1,27 @@
+# RadioListTile.onChanged deprecation対応
+
+## Issue概要
+Flutterの新バージョンで `RadioListTile.onChanged` および `groupValue` が deprecated となったため、代替APIへ移行した。
+
+## 実装方針
+- 各 `RadioListTile` に直接設定していた `onChanged`・`groupValue` を、親ウィジェットである `RadioGroup` に集約する
+- 保存中の無効化を `onChanged: null` から `enabled: !isSaving` に変更する
+- テストコードも同様の修正を適用する
+
+## 変更ファイル
+
+### `lib/screens/settings_screen.dart`
+- `RadioListTile` ごとに設定していた `groupValue` と `onChanged` を削除
+- `RadioGroup<AppTheme>` / `RadioGroup<AppFontSize>` の `onChanged` にコールバックを集約
+- `RadioListTile` には `enabled: !isSaving` を設定して保存中の操作を無効化
+
+### `test/settings_screen_test.dart`
+- `radio.onChanged` チェックを `radio.enabled` チェックに変更
+- 保存中の保存ボタン確認を `find.widgetWithText(TextButton, '保存')` から `find.byType(TextButton)` に変更（保存中はボタンのchildがCircularProgressIndicatorになるため）
+- Navigator取得を `tester.state(find.byType(Navigator))` から `GlobalKey<NavigatorState>` を使った取得に変更（MaterialApp内部のNavigatorと競合するため）
+
+## テスト方針
+既存の18テストがすべて通過することを確認済み。新規テストの追加は不要（既存テストが動作確認を兼ねる）。
+
+## 既知の制約
+なし

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -64,46 +64,56 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 padding: EdgeInsets.fromLTRB(16, 16, 16, 4),
                 child: Text('テーマ', style: TextStyle(fontWeight: FontWeight.bold)),
               ),
-              RadioListTile<AppTheme>(
-                title: const Text('システム'),
-                value: AppTheme.system,
+              RadioGroup<AppTheme>(
                 groupValue: settings.theme,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateThemePreview(v!),
-              ),
-              RadioListTile<AppTheme>(
-                title: const Text('ライト'),
-                value: AppTheme.light,
-                groupValue: settings.theme,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateThemePreview(v!),
-              ),
-              RadioListTile<AppTheme>(
-                title: const Text('ダーク'),
-                value: AppTheme.dark,
-                groupValue: settings.theme,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateThemePreview(v!),
+                onChanged: (v) => widget.notifier.updateThemePreview(v!),
+                child: Column(
+                  children: [
+                    RadioListTile<AppTheme>(
+                      title: const Text('システム'),
+                      value: AppTheme.system,
+                      enabled: !isSaving,
+                    ),
+                    RadioListTile<AppTheme>(
+                      title: const Text('ライト'),
+                      value: AppTheme.light,
+                      enabled: !isSaving,
+                    ),
+                    RadioListTile<AppTheme>(
+                      title: const Text('ダーク'),
+                      value: AppTheme.dark,
+                      enabled: !isSaving,
+                    ),
+                  ],
+                ),
               ),
               const Divider(),
               const Padding(
                 padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
                 child: Text('フォントサイズ', style: TextStyle(fontWeight: FontWeight.bold)),
               ),
-              RadioListTile<AppFontSize>(
-                title: const Text('小'),
-                value: AppFontSize.small,
+              RadioGroup<AppFontSize>(
                 groupValue: settings.fontSize,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateFontSizePreview(v!),
-              ),
-              RadioListTile<AppFontSize>(
-                title: const Text('中'),
-                value: AppFontSize.medium,
-                groupValue: settings.fontSize,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateFontSizePreview(v!),
-              ),
-              RadioListTile<AppFontSize>(
-                title: const Text('大'),
-                value: AppFontSize.large,
-                groupValue: settings.fontSize,
-                onChanged: isSaving ? null : (v) => widget.notifier.updateFontSizePreview(v!),
+                onChanged: (v) => widget.notifier.updateFontSizePreview(v!),
+                child: Column(
+                  children: [
+                    RadioListTile<AppFontSize>(
+                      title: const Text('小'),
+                      value: AppFontSize.small,
+                      enabled: !isSaving,
+                    ),
+                    RadioListTile<AppFontSize>(
+                      title: const Text('中'),
+                      value: AppFontSize.medium,
+                      enabled: !isSaving,
+                    ),
+                    RadioListTile<AppFontSize>(
+                      title: const Text('大'),
+                      value: AppFontSize.large,
+                      enabled: !isSaving,
+                    ),
+                  ],
+                ),
               ),
             ],
           ),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/test/settings_screen_test.dart
+++ b/test/settings_screen_test.dart
@@ -78,19 +78,15 @@ void main() {
     testWidgets('デフォルトではシステムテーマが選択されている', (tester) async {
       final notifier = await createNotifier();
       await tester.pumpWidget(MaterialApp(home: SettingsScreen(notifier: notifier)));
-      final radio = tester.widgetList<RadioListTile<AppTheme>>(
-        find.byType(RadioListTile<AppTheme>),
-      ).firstWhere((r) => r.value == AppTheme.system);
-      expect(radio.groupValue, AppTheme.system);
+      final group = tester.widget<RadioGroup<AppTheme>>(find.byType(RadioGroup<AppTheme>));
+      expect(group.groupValue, AppTheme.system);
     });
 
     testWidgets('デフォルトでは中フォントが選択されている', (tester) async {
       final notifier = await createNotifier();
       await tester.pumpWidget(MaterialApp(home: SettingsScreen(notifier: notifier)));
-      final radio = tester.widgetList<RadioListTile<AppFontSize>>(
-        find.byType(RadioListTile<AppFontSize>),
-      ).firstWhere((r) => r.value == AppFontSize.medium);
-      expect(radio.groupValue, AppFontSize.medium);
+      final group = tester.widget<RadioGroup<AppFontSize>>(find.byType(RadioGroup<AppFontSize>));
+      expect(group.groupValue, AppFontSize.medium);
     });
   });
 
@@ -141,7 +137,7 @@ void main() {
       await tester.pump(); // save開始、まだ完了していない
 
       // 保存中はボタンが無効（onPressedがnull）
-      final button = tester.widget<TextButton>(find.widgetWithText(TextButton, '保存'));
+      final button = tester.widget<TextButton>(find.byType(TextButton));
       expect(button.onPressed, isNull);
 
       service.completeSuccess();
@@ -177,7 +173,7 @@ void main() {
         find.byType(RadioListTile<AppTheme>),
       );
       for (final radio in radios) {
-        expect(radio.onChanged, isNull);
+        expect(radio.enabled, isFalse);
       }
 
       service.completeSuccess();
@@ -265,8 +261,10 @@ void main() {
   group('SettingsScreen 離脱時プレビュー破棄', () {
     testWidgets('保存せずに画面を離脱するとプレビューがsavedSettingsに戻る', (tester) async {
       final notifier = await createNotifier();
+      final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(MaterialApp(
         home: Navigator(
+          key: navigatorKey,
           onGenerateRoute: (_) => MaterialPageRoute(
             builder: (_) => Scaffold(
               body: Builder(
@@ -295,8 +293,7 @@ void main() {
       expect(notifier.settings.theme, AppTheme.dark);
 
       // 保存せずに戻る
-      final NavigatorState navigator = tester.state(find.byType(Navigator));
-      navigator.pop();
+      navigatorKey.currentState!.pop();
       await tester.pumpAndSettle();
 
       // プレビューが破棄されてsavedSettings(system)に戻る
@@ -305,8 +302,10 @@ void main() {
 
     testWidgets('保存してから画面を離脱してもsavedSettingsは維持される', (tester) async {
       final notifier = await createNotifier();
+      final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(MaterialApp(
         home: Navigator(
+          key: navigatorKey,
           onGenerateRoute: (_) => MaterialPageRoute(
             builder: (_) => Scaffold(
               body: Builder(
@@ -335,8 +334,7 @@ void main() {
       expect(notifier.savedSettings.theme, AppTheme.dark);
 
       // 保存後に戻る
-      final NavigatorState navigator = tester.state(find.byType(Navigator));
-      navigator.pop();
+      navigatorKey.currentState!.pop();
       await tester.pumpAndSettle();
 
       // 保存済み設定はダークのまま


### PR DESCRIPTION
## Summary
- `RadioListTile` の `onChanged`/`groupValue` を `RadioGroup` ウィジェットに集約
- 保存中の無効化を `onChanged: null` → `enabled: !isSaving` に変更
- テストも同様に `radio.onChanged` → `radio.enabled`、Navigator取得を `GlobalKey` に変更

## Test plan
- [ ] `flutter test test/settings_screen_test.dart` で全18テストが通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)